### PR TITLE
update-db: stream each update's returned message as it runs

### DIFF
--- a/commands/update.bee.inc
+++ b/commands/update.bee.inc
@@ -93,11 +93,69 @@ function update_db_bee_callback() {
       return;
     }
 
-    // Apply the updates, without calling `backdrop_goto()`.
-    // @see batch_process()
-    $batch = &batch_get();
-    $batch['progressive'] = FALSE;
-    update_batch($start);
-    bee_message(bt('All pending updates applied.'), 'success');
+    // Take the site offline while schema changes run, as update_batch() does.
+    $_SESSION['maintenance_mode'] = state_get('maintenance_mode', FALSE);
+    if ($_SESSION['maintenance_mode'] == FALSE) {
+      state_set('maintenance_mode', TRUE);
+    }
+
+    // Resolve dependencies to order the updates.
+    $updates = update_resolve_dependencies($start);
+    $dependency_map = array();
+    foreach ($updates as $function => $update) {
+      $dependency_map[$function] = !empty($update['reverse_paths']) ? array_keys($update['reverse_paths']) : array();
+    }
+
+    // Run each update directly (not via update_batch) so its result prints as it finishes.
+    $context = array('results' => array());
+    foreach ($updates as $update) {
+      if (empty($update['allowed'])) {
+        continue;
+      }
+      $module = $update['module'];
+      $number = $update['number'];
+      $function = $module . '_update_' . $number;
+
+      // Start each module just before its first pending update.
+      if (isset($start[$module])) {
+        backdrop_set_installed_schema_version($module, $number - 1);
+        unset($start[$module]);
+      }
+
+      // bee_instant_message() prints now; bee_message() would batch to the end.
+      bee_instant_message(bt('Update started: !function', array('!function' => $function)), 'info');
+
+      // Long-running updates re-run until $context['finished'] reaches 1.
+      $context['sandbox'] = array();
+      do {
+        $context['finished'] = 1;
+        update_do_one($module, $number, $dependency_map[$function], $context);
+      } while ($context['finished'] < 1);
+
+      $result = isset($context['results'][$module][$number]) ? $context['results'][$module][$number] : array();
+      if (!empty($result['results']['query'])) {
+        bee_instant_message(trim(strip_tags($result['results']['query'])), !empty($result['results']['success']) ? 'success' : 'error');
+      }
+
+      // Stop on abort; dependent updates can no longer run safely.
+      if (!empty($context['results']['#abort'])) {
+        if (!empty($result['#abort']['query'])) {
+          bee_instant_message(trim(strip_tags($result['#abort']['query'])), 'error');
+        }
+        bee_instant_message(bt('Update aborted: !function', array('!function' => $function)), 'error');
+        break;
+      }
+
+      bee_instant_message(bt('Update completed: !function', array('!function' => $function)), 'info');
+    }
+
+    // Flush caches and restore the site, as update_finished() does.
+    backdrop_flush_all_caches();
+    if (isset($_SESSION['maintenance_mode']) && $_SESSION['maintenance_mode'] == FALSE) {
+      state_set('maintenance_mode', FALSE);
+      unset($_SESSION['maintenance_mode']);
+    }
+
+    bee_instant_message(bt('Finished performing updates.'), 'success');
   }
 }


### PR DESCRIPTION
Fixes #494

The streaming approach: run each update inline and print its returned message the moment that update finishes (live per-update output, bracketed by "Update started/completed"), instead of collecting them for a single dump at the end.

More code than the end-of-batch alternative (#495) because it drives `update_do_one()` itself rather than `update_batch()`. Pick whichever approach you prefer.
